### PR TITLE
Add IOCTLs to the dummy Gramine device

### DIFF
--- a/gramine-device-testing-module/README.rst
+++ b/gramine-device-testing-module/README.rst
@@ -10,14 +10,25 @@ all required functionality (e.g shared untrusted memory and ioctl syscall).
 Features
 ========
 
-This driver implements a custom character device, which allows for simple string
-manipulations. Each open file handle is associated with a context holding all
-necessary data, and allows for the following operations:
+This driver implements a custom character device, which allows for simple byte
+array manipulations. Each open file handle is associated with a context holding
+all necessary data, and allows for the following operations:
 
-  - `open` - Create a string instance.
-  - `write` - Write data to the string at the current offset. If some data was
-    present at this offset, it's overwritten. The string is automatically
-    extended if needed.
-  - `read` - Read that from the string.
-  - `llseek` - Change the current offset in the string.
-  - `release` - Releases the string instance.
+  - `open` - Create a byte array instance.
+  - `write` - Write data to the byte array at the current offset. If some data
+    was present at this offset, it's overwritten. The byte array is
+    automatically extended if needed.
+  - `read` - Read data from the byte array.
+  - `llseek` - Change the current offset in the byte array.
+  - `release` - Releases the byte array instance.
+  - `unlocked_ioctl` - Perform one of the following IOCTLs:
+    - `GRAMINE_TEST_DEV_IOCTL_REWIND` - same as `llseek(filp, 0, SEEK_SET)`.
+    - `GRAMINE_TEST_DEV_IOCTL_WRITE` - same as `write`.
+    - `GRAMINE_TEST_DEV_IOCTL_READ` - same as `read`.
+    - `GRAMINE_TEST_DEV_IOCTL_GETSIZE` - Returns size of the byte array.
+    - `GRAMINE_TEST_DEV_IOCTL_CLEAR` - Frees the byte array.
+    - `GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR` - Replaces specified characters in
+      the byte array; character replacements are passed as an array.
+    - `GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST` - same as
+      `GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR` but character replacements are passed
+      as a NULL-terminated list.

--- a/gramine-device-testing-module/gramine_test_dev_ioctl.h
+++ b/gramine-device-testing-module/gramine_test_dev_ioctl.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <linux/ioctl.h>
+
+struct gramine_test_dev_ioctl_write {
+    size_t buf_size;        /* in */
+    const char __user* buf; /* in */
+    loff_t off;             /* in/out -- updated after write */
+    ssize_t copied;         /* out -- how many bytes were actually written */
+};
+
+struct gramine_test_dev_ioctl_read {
+    size_t buf_size;        /* in */
+    char __user* buf;       /* out */
+    loff_t off;             /* in/out -- updated after read */
+    ssize_t copied;         /* out -- how many bytes were actually read */
+};
+
+struct gramine_test_dev_ioctl_replace_char {
+    char src;               /* in */
+    char dst;               /* in */
+    char pad[6];
+};
+
+struct gramine_test_dev_ioctl_replace_arr {
+    /* array of replacements, e.g. replacements_cnt == 2 and [`l` -> `$`, `o` -> `0`] */
+    size_t replacements_cnt;
+    struct gramine_test_dev_ioctl_replace_char __user* replacements_arr;
+};
+
+struct gramine_test_dev_ioctl_replace_list {
+    /* list of replacements, e.g. [`l` -> `$`, next points to `o` -> `0`, next points to NULL] */
+    struct gramine_test_dev_ioctl_replace_char replacement;
+    struct gramine_test_dev_ioctl_replace_list __user* next;
+};
+
+#define GRAMINE_TEST_DEV_IOCTL_BASE 0x81
+
+#define GRAMINE_TEST_DEV_IOCTL_REWIND        _IO(GRAMINE_TEST_DEV_IOCTL_BASE, 0x00)
+#define GRAMINE_TEST_DEV_IOCTL_WRITE       _IOWR(GRAMINE_TEST_DEV_IOCTL_BASE, 0x01, \
+                                                 struct gramine_test_dev_ioctl_write)
+#define GRAMINE_TEST_DEV_IOCTL_READ        _IOWR(GRAMINE_TEST_DEV_IOCTL_BASE, 0x02, \
+                                                 struct gramine_test_dev_ioctl_read)
+#define GRAMINE_TEST_DEV_IOCTL_GETSIZE       _IO(GRAMINE_TEST_DEV_IOCTL_BASE, 0x03)
+#define GRAMINE_TEST_DEV_IOCTL_CLEAR         _IO(GRAMINE_TEST_DEV_IOCTL_BASE, 0x04)
+#define GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR  _IOW(GRAMINE_TEST_DEV_IOCTL_BASE, 0x05, \
+                                                 struct gramine_test_dev_ioctl_replace_arr)
+#define GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST _IOW(GRAMINE_TEST_DEV_IOCTL_BASE, 0x06, \
+                                                 struct gramine_test_dev_ioctl_replace_list)


### PR DESCRIPTION
New IOCTLs (simple string manipulations):
- GRAMINE_IOCTL_REWIND
- GRAMINE_IOCTL_WRITE
- GRAMINE_IOCTL_READ
- GRAMINE_IOCTL_GETSIZE
- GRAMINE_IOCTL_CLEAR
- GRAMINE_IOCTL_REPLACE_ARR
- GRAMINE_IOCTL_REPLACE_LIST

Companion PR: https://github.com/gramineproject/gramine/pull/671

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/device-testing-tools/4)
<!-- Reviewable:end -->
