### PR TITLE
Run chroot as busybox applet in first init script

### DIFF
--- a/initramfs_builder/init
+++ b/initramfs_builder/init
@@ -29,4 +29,4 @@ mount -t tmpfs tmpfs /newroot/tmp
 umount -l /dev
 cd /newroot
 mount --move . /
-exec chroot . /init
+exec /bin/busybox chroot . /init


### PR DESCRIPTION
For some reason after mount-move Linux resolves `/` and `/bin/..` differently.

Signed-off-by: Borys Popławski <borysp@invisiblethingslab.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/device-testing-tools/5)
<!-- Reviewable:end -->
