### PR TITLE
Add Jenkins-specific `init` script to run inside VM

### DIFF
--- a/initramfs_builder/new_init_jenkins
+++ b/initramfs_builder/new_init_jenkins
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -ex
+
+echo "PREP STARTING"
+
+# QEMU appends `PWD_FOR_VM=<current Jenkins working dir>` to Linux command line
+cd $PWD_FOR_VM
+. "$PWD/envs"
+
+# to find insmod and poweroff programs
+export PATH="/sbin:$PATH"
+
+cd device-testing-tools/gramine-device-testing-module
+insmod gramine-testing-dev.ko
+cd -
+
+echo "PREP DONE"
+
+if test -n "$SGX"; then
+    GRAMINE=gramine-sgx
+else
+    GRAMINE=gramine-direct
+fi
+
+cd libos/test/regression
+gramine-test build helloworld
+$GRAMINE helloworld
+
+gramine-test build device_ioctl
+$GRAMINE device_ioctl
+cd -
+
+echo "TESTS OK"
+
+poweroff -n -f

--- a/initramfs_builder/run.sh
+++ b/initramfs_builder/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 exec qemu-system-x86_64 \
     -enable-kvm \
@@ -11,7 +11,7 @@ exec qemu-system-x86_64 \
     -cpu host \
     -smp 2 \
     -m 1G \
-    -append "console=ttyS0 loglevel=3 quiet oops=panic" \
+    -append "console=ttyS0 loglevel=3 quiet oops=panic PWD_FOR_VM=\"${1:-$PWD}\"" \
     -device virtio-rng-pci \
     -virtfs 'local,path=/,id=hostfs,mount_tag=hostfs,security_model=none,readonly=on' \
     -device 'virtio-9p-pci,fsdev=hostfs,mount_tag=hostfs' \


### PR DESCRIPTION
Currently it performs only three steps:
- inserts the Gramine testing device,
- builds the `device_ioctl` LibOS regression test,
- runs this test in non-SGX and SGX modes.

Based on @boryspoplawski's PR #5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/device-testing-tools/6)
<!-- Reviewable:end -->
