### PR TITLE
Add Jenkins-specific `init` script to run inside VM

### DIFF
--- a/initramfs_builder/new_init
+++ b/initramfs_builder/new_init
@@ -1,7 +1,38 @@
 #!/bin/sh
 
-set -e
+set -ex
 
-setsid /bin/bash -i
+echo "PREP STARTING"
+
+# QEMU appends `PWD_FOR_VM=<current Jenkins working dir>` to Linux command line
+cd $PWD_FOR_VM
+. "$PWD/envs"
+
+# to find insmod and poweroff programs (default PATH doesn't have `/sbin`)
+export PATH="/sbin:$PATH"
+
+if test -n "$SGX"; then
+    GRAMINE=gramine-sgx
+else
+    GRAMINE=gramine-direct
+fi
+
+(
+    cd device-testing-tools/gramine-device-testing-module
+    insmod gramine-testing-dev.ko
+)
+echo "PREP DONE"
+
+(
+    # run only couple tests -- executing in a VM with virtio-9p-pci FS passthrough is very slow
+    cd libos/test/regression
+
+    gramine-test build helloworld
+    $GRAMINE helloworld
+
+    gramine-test build device_ioctl
+    $GRAMINE device_ioctl
+)
+echo "TESTS OK"
 
 poweroff -n -f

--- a/initramfs_builder/new_init_shell
+++ b/initramfs_builder/new_init_shell
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# this new_init with a Bash shell can be used for manual testing
+
+set -e
+
+setsid /bin/bash -i
+
+poweroff -n -f

--- a/initramfs_builder/run.sh
+++ b/initramfs_builder/run.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 exec qemu-system-x86_64 \
     -enable-kvm \
     -kernel /boot/vmlinuz-$(uname -r) \
-    -initrd initramfs.cpio.gz \
+    -initrd ${1:-initramfs.cpio.gz} \
     -nographic \
     -monitor /dev/null \
     -cpu host \
     -smp 2 \
     -m 1G \
-    -append "console=ttyS0 loglevel=3 quiet oops=panic" \
+    -append "console=ttyS0 loglevel=3 quiet oops=panic PWD_FOR_VM=\"${2:-$PWD}\"" \
     -device virtio-rng-pci \
     -virtfs 'local,path=/,id=hostfs,mount_tag=hostfs,security_model=none,readonly=on' \
     -device 'virtio-9p-pci,fsdev=hostfs,mount_tag=hostfs' \


### PR DESCRIPTION
This PR adds a Jenkins-specific `init` script (replacing old `new_init`) to run inside VM.

Currently it performs only two steps:
- inserts the Gramine testing device,
- runs `helloworld` and `device_ioctl` LibOS regression tests.

The old `new_init` script (useful for manual testing) is renamed to `new_init_shell`.

This is a reincarnation of https://github.com/gramineproject/device-testing-tools/pull/6 (that PR had a wrong target branch and was closed without the possibility of reopening).

See also discussions in https://github.com/gramineproject/gramine/pull/1098

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/device-testing-tools/7)
<!-- Reviewable:end -->
