### PR TITLE
Add `GRAMINE_TEST_DEV_IOCTL_GET_SET_SIZE` ioctl to the Gramine test device

### DIFF
--- a/gramine-device-testing-module/README.rst
+++ b/gramine-device-testing-module/README.rst
@@ -35,3 +35,5 @@ all necessary data, and allows for the following operations:
   - `GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST` - same as
     `GRAMINE_TEST_DEV_IOCTL_REPLACE_ARR` but character replacements are passed
     as a NULL-terminated list.
+  - `GRAMINE_TEST_DEV_IOCTL_GET_SET_SIZE` - Gets or sets the size of the byte
+    array. The size can be set only to zero (same behavior as `_CLEAR`).

--- a/gramine-device-testing-module/gramine_test_dev_ioctl.h
+++ b/gramine-device-testing-module/gramine_test_dev_ioctl.h
@@ -42,6 +42,12 @@ struct gramine_test_dev_ioctl_replace_list {
     struct gramine_test_dev_ioctl_replace_list __user* next;
 };
 
+struct gramine_test_dev_ioctl_get_set_size {
+    uint8_t do_set; /* 1 means set the size, 0 means get the size */
+    uint8_t pad[7];
+    size_t size;    /* in if set the size, out if get the size */
+};
+
 #define GRAMINE_TEST_DEV_IOCTL_BASE 0x81
 
 #define GRAMINE_TEST_DEV_IOCTL_REWIND        _IO(GRAMINE_TEST_DEV_IOCTL_BASE, 0x00)
@@ -55,3 +61,5 @@ struct gramine_test_dev_ioctl_replace_list {
                                                  struct gramine_test_dev_ioctl_replace_arr)
 #define GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST _IOW(GRAMINE_TEST_DEV_IOCTL_BASE, 0x06, \
                                                  struct gramine_test_dev_ioctl_replace_list)
+#define GRAMINE_TEST_DEV_IOCTL_GET_SET_SIZE  _IOWR(GRAMINE_TEST_DEV_IOCTL_BASE, 0x07, \
+                                                   struct gramine_test_dev_ioctl_get_set_size)

--- a/gramine-device-testing-module/main.c
+++ b/gramine-device-testing-module/main.c
@@ -212,6 +212,27 @@ static ssize_t gramine_test_dev_ioctl(struct file *filp, unsigned int cmd, unsig
             return gramine_test_dev_replace_arr(data, argp_user);
         case GRAMINE_TEST_DEV_IOCTL_REPLACE_LIST:
             return gramine_test_dev_replace_list(data, argp_user);
+        case GRAMINE_TEST_DEV_IOCTL_GET_SET_SIZE: {
+            struct gramine_test_dev_ioctl_get_set_size arg;
+            if (copy_from_user(&arg, argp_user, sizeof(arg))) {
+                return -EFAULT;
+            }
+            if (arg.do_set) {
+                if (arg.size != 0) {
+                    pr_warn("GET_SET_SIZE failed: currently can only set the size to zero\n");
+                    return -EINVAL;
+                }
+                kfree(data->buf);
+                data->size = 0;
+                data->buf  = NULL;
+                return 0;
+            }
+            arg.size = data->size;
+            if (copy_to_user(argp_user, &arg, sizeof(arg))) {
+                return -EFAULT;
+            }
+            return 0;
+        }
         default:
             return -EINVAL;
     }


### PR DESCRIPTION
This ioctl can be used to test the `onlyif` keyword of Gramine ioctl manifest syntax.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/device-testing-tools/9)
<!-- Reviewable:end -->
