### PR TITLE
Add `virtio_pci` to loaded modules; leave only `-virtfs`

### DIFF
--- a/initramfs_builder/Makefile
+++ b/initramfs_builder/Makefile
@@ -44,6 +44,7 @@ $(addprefix $(INITRAMFS_DIR)/,$(INIT_FILES)): $(INITRAMFS_DIR)/%: % $(INITRAMFS_
 insert_modules.sh:
 	modprobe --show-depends 9p > $@
 	modprobe --show-depends 9pnet_virtio >> $@
+	modprobe --show-depends virtio_pci >> $@
 	modprobe --show-depends overlay >> $@
 	sed -i '/builtin/d' $@
 

--- a/initramfs_builder/run.sh
+++ b/initramfs_builder/run.sh
@@ -15,7 +15,6 @@ exec qemu-system-x86_64 \
     -m 1G \
     -append "console=ttyS0 loglevel=3 quiet oops=panic $*" \
     -device virtio-rng-pci \
-    -virtfs 'local,path=/,id=hostfs,mount_tag=hostfs,security_model=none,readonly=on' \
-    -device 'virtio-9p-pci,fsdev=hostfs,mount_tag=hostfs' \
+    -virtfs local,path=/,id=hostfs,mount_tag=hostfs,security_model=none,readonly \
     -object memory-backend-epc,id=epc_mem,size=64M,prealloc=on \
     -M sgx-epc.0.memdev=epc_mem


### PR DESCRIPTION
Guest kernel may not have `virtio_pci` module loaded by default, so load it explicitly. Also, `-virtfs` is a synonym to `-device 'virtio-9p-pci'` so the latter is redundant and can be removed.

For more info and context, see https://github.com/gramineproject/device-testing-tools/issues/2#issuecomment-1692814889

This was detected while trying to fix the Gramine Jenkins CI job `linux-sgx-vm-gcc-release`, which started failing after updating the host OS to Debian 12 (from Debian 11).