### PR TITLE
Use new `class_create()` API when kernel is 6.4.0 or higher

### DIFF
--- a/gramine-device-testing-module/main.c
+++ b/gramine-device-testing-module/main.c
@@ -9,6 +9,7 @@
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 #include "gramine_test_dev_ioctl.h"
 
@@ -272,7 +273,11 @@ static int gramine_test_dev_change_perms_uevent(struct device* dev, struct kobj_
 static int __init gramine_test_dev_init_module(void) {
     int ret;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+    gramine_test_dev_class = class_create(GRAMINE_TEST_DEV_NAME);
+#else
     gramine_test_dev_class = class_create(THIS_MODULE, GRAMINE_TEST_DEV_NAME);
+#endif
     if (IS_ERR(gramine_test_dev_class)) {
         ret = PTR_ERR(gramine_test_dev_class);
         gramine_test_dev_class = NULL;


### PR DESCRIPTION
The module pointer in `class_create()` device driver API was removed since Linux kernel version 6.4.0 (Linux kernel commit [1aaba11da9](https://github.com/torvalds/linux/commit/1aaba11da9)).

This commit uses the new API when the kernel version is 6.4.0 or higher and otherwise falls back to the old API to avoid compilation issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/device-testing-tools/11)
<!-- Reviewable:end -->
